### PR TITLE
Flexible store names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,9 +45,12 @@ export default function (Vue, {
     },
 
     created() {
-      const { persist } = this.$options
+      const { persist, persistStoreName, persistNamespaced } = this.$options
       if (persist) {
-        this.$persist(persist)
+        if (persistNamespaced === true)
+          persistStoreName = `persist:${this.$options.name}`
+        // persistStoreName may be undefined, $persist() will assume the default value
+        this.$persist(persist, persistStoreName)
       }
     }
   })


### PR DESCRIPTION
Ability to specify the store name on the component as ```persistStoreName``` or to have one automatically taken to be the component's name via ```persistNamespaced```.