### PR TITLE
Option for namespacing persisted variable names

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "test": "echo 'no tests!' && npm run lint && npm run build",
     "lint": "xo",
+    "prepare": "npm run build",
     "build": "bili --name vue-persist --format umd --module-name VuePersist",
     "build:example": "poi build",
     "dev": "poi",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,10 @@
+const toKebabCase = str =>
+    str &&
+    str
+        .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+        .map(x => x.toLowerCase())
+        .join('-')
+
 export default function (Vue, {
   name: defaultStoreName = 'persist:store',
   expiration: defaultExpiration,
@@ -9,7 +16,7 @@ export default function (Vue, {
 
   Vue.mixin({
     beforeCreate() {
-      this.$persist = (names, storeName = defaultStoreName, storeExpiration = defaultExpiration) => {
+      this.$persist = (names, storeName = this.name ? 'persist:' + toKebabCase(this.name) : defaultStoreName, storeExpiration = defaultExpiration) => {
         let store = cache[storeName] = JSON.parse(read(storeName) || '{}')
         store.data = store.data || {}
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default function (Vue, {
 
   Vue.mixin({
     beforeCreate() {
-      this.$persist = (names, storeName = this.name ? 'persist:' + toKebabCase(this.name) : defaultStoreName, storeExpiration = defaultExpiration) => {
+      this.$persist = (names, storeName =  defaultStoreName, storeExpiration = defaultExpiration) => {
         let store = cache[storeName] = JSON.parse(read(storeName) || '{}')
         store.data = store.data || {}
 
@@ -52,9 +52,12 @@ export default function (Vue, {
     },
 
     created() {
-      const { persist } = this.$options
+      const { persist, persistOwnStore, name } = this.$options
       if (persist) {
-        this.$persist(persist)
+          const storeName = persistOwnStore ?
+              ( persistOwnStore === true ) ? 'persist:' + toKebabCase(name) : 'persist:' + String(persistOwnStore)
+              : undefined
+        this.$persist(persist, storeName)
       }
     }
   })

--- a/src/index.js
+++ b/src/index.js
@@ -52,10 +52,10 @@ export default function (Vue, {
     },
 
     created() {
-      const { persist, persistOwnStore, name } = this.$options
+      const { persist, persistKey, name } = this.$options
       if (persist) {
-          const storeName = persistOwnStore ?
-              ( persistOwnStore === true ) ? 'persist:' + toKebabCase(name) : 'persist:' + String(persistOwnStore)
+          const storeName = persistKey ?
+              ( persistKey === true ) ? `persist:${toKebabCase(name)}` : `persist:${String(persistKey)}`
               : undefined
         this.$persist(persist, storeName)
       }

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default function (Vue, {
 
   Vue.mixin({
     beforeCreate() {
-      this.$persist = (names, storeName =  defaultStoreName, storeExpiration = defaultExpiration) => {
+      this.$persist = (names, storeName = defaultStoreName, storeExpiration = defaultExpiration) => {
         let store = cache[storeName] = JSON.parse(read(storeName) || '{}')
         store.data = store.data || {}
 


### PR DESCRIPTION
Plus the npm hook to build the project when installed directly from a repository.

Settings `persistKey: true` generates a storage key based on the component's name. `persistKey: 'my-own-name'` - will prefix that value with `persist:` and use the latter as the key.